### PR TITLE
pyproject.toml: fix installation using pip by adding authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Package containing a DWA module which can be used to implement a DenseFormer with dilation and DWA period."
 license = "Apache"
 readme = "README.md"
+authors = [
+    "Matteo Pagliardini <matteo.pagliardini@gmail.com>",
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Pip installation, at least in non-editable mode, requires the authors section. Otherwise there is an error:

  RuntimeError: The Poetry configuration is invalid:
  - The fields ['authors'] are required in package mode.